### PR TITLE
Ssh manager

### DIFF
--- a/SSH/SshManager.php
+++ b/SSH/SshManager.php
@@ -36,7 +36,13 @@ class SshManager {
                     break;
             }
         } else {
-            $proxy = new PeclSsh2Proxy();
+            if(extension_loaded ('php-ssh2'))
+            {
+                $proxy = new PeclSsh2Proxy();
+            } else {
+                $proxy = new CLISshProxy();
+            }
+
         }
 
         $this->proxy = $proxy;


### PR DESCRIPTION
## Fix SshManager construct method

SSH Manager didn't acted as documented. In case of not defining a ssh proxy in the configuration file the SshManager wasn't able to connect to the remote server. In the documentation it's said that if you don't define a proxy PeclSsh2Proxy will be used by default. 

This fixes this problem by adding the default proxy to the construct method of the SshManager class. 
