### PR TITLE
Several Fixes and Improvements

### DIFF
--- a/Command/MigrateCommand.php
+++ b/Command/MigrateCommand.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * This file is part of the JordiLlonchDeployBundle
+ *
+ * (c) Jordi Llonch <llonch.jordi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JordiLlonch\Bundle\DeployBundle\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\Output;
+
+class MigrateCommand extends BaseCommand
+{
+    protected function configure()
+    {
+        parent::configure();
+
+        $this
+            ->setName('deployer:migrate')
+            ->addArgument('version',InputArgument::OPTIONAL,'Specified version to migrate')
+            ->setDescription('Run doctrine migrations.')
+            ->setHelp(<<<EOT
+The <info>deployer:migrate</info> command will run a migration to a specified version or the latest avaliable version.
+EOT
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $version = $input->getArgument('version');
+
+        if($input->isInteractive()) {
+            $dialog = $this->getHelperSet()->get('dialog');
+            $confirmation = $dialog->askConfirmation($output, '<question>WARNING! You are about to migrate the database. Are you sure you wish to continue? (y/n)</question>', false);
+        }
+        else $confirmation = true;
+
+        if ($confirmation === true) {
+            $this->deployer->runMigration($version);
+        } else {
+            $output->writeln('<error>Migration cancelled!</error>');
+        }
+    }
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -64,7 +64,7 @@ class Configuration implements ConfigurationInterface
                                     ->end()
                                     ->scalarNode('public_key_file')
                                     ->end()
-                                    ->scalarNode('private_key_file')->isRequired()
+                                    ->scalarNode('private_key_file')
                                     ->end()
                                     ->scalarNode('private_key_file_pwd')
                                     ->end()

--- a/Helpers/FilesHelper.php
+++ b/Helpers/FilesHelper.php
@@ -39,4 +39,22 @@ class FilesHelper extends Helper {
 
         return true;
     }
+
+    public function copyFile($origin_path,$destination_path)
+    {
+        $error = "";
+        if(!file_exists($origin_path))
+        {
+            return 'File "'. $origin_path .'" does not exists.';
+        }
+
+        $result = copy($origin_path,$destination_path);
+
+        if($result === false)
+        {
+            return 'File "'. $origin_path .'" not copied to "'.$destination_path.'"';
+        }
+
+        return true;
+    }
 }

--- a/Helpers/Symfony2Helper.php
+++ b/Helpers/Symfony2Helper.php
@@ -48,7 +48,7 @@ class Symfony2Helper extends Helper {
     {
         $localNewRepositoryDir = $this->getDeployer()->getLocalNewRepositoryDir();
         $this->getDeployer()->exec('rm -rf ' . $localNewRepositoryDir . '/web/bundles');
-        $this->getDeployer()->exec('php ' . $localNewRepositoryDir . '/app/console assets:install  --env=prod --no-debug');
+        $this->getDeployer()->exec('php ' . $localNewRepositoryDir . '/app/console assets:install '.$localNewRepositoryDir . '/web/bundles  --env=prod --no-debug');
     }
 
     public function asseticDump()

--- a/Helpers/Symfony2Helper.php
+++ b/Helpers/Symfony2Helper.php
@@ -43,4 +43,17 @@ class Symfony2Helper extends Helper {
         $filesHelper->filesReplacePattern($paths, $pattern, $replace);
         $this->getDeployer()->exec('chmod -R a+wr ' . $localNewRepositoryDir . '/app/cache');
     }
+
+    public function assetsDump()
+    {
+        $localNewRepositoryDir = $this->getDeployer()->getLocalNewRepositoryDir();
+        $this->getDeployer()->exec('rm -rf ' . $localNewRepositoryDir . '/web/bundles');
+        $this->getDeployer()->exec('php ' . $localNewRepositoryDir . '/app/console assets:install  --env=prod --no-debug');
+    }
+
+    public function asseticDump()
+    {
+        $localNewRepositoryDir = $this->getDeployer()->getLocalNewRepositoryDir();
+        $this->getDeployer()->exec('php ' . $localNewRepositoryDir . '/app/console assetic:dump  --env=prod --no-debug');
+    }
 }

--- a/Helpers/Symfony2Helper.php
+++ b/Helpers/Symfony2Helper.php
@@ -48,7 +48,7 @@ class Symfony2Helper extends Helper {
     {
         $localNewRepositoryDir = $this->getDeployer()->getLocalNewRepositoryDir();
         $this->getDeployer()->exec('rm -rf ' . $localNewRepositoryDir . '/web/bundles');
-        $this->getDeployer()->exec('php ' . $localNewRepositoryDir . '/app/console assets:install '.$localNewRepositoryDir . '/web/bundles  --env=prod --no-debug');
+        $this->getDeployer()->exec('php ' . $localNewRepositoryDir . '/app/console assets:install '.$localNewRepositoryDir . '/web  --env=prod --no-debug');
     }
 
     public function asseticDump()

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ prod_myproj:
         - deploy@testserver2:8822
 ```
 
-* Note: Servers urls are in other file (`parameters_deployers_servers.yml`) because this file contains a dynamic configuration that would be changed in a scalable environment like AWS.
+* Note: Servers urls are in other file (`parameters_deployer_servers.yml`) because this file contains a dynamic configuration that would be changed in a scalable environment like AWS.
 
 
 ### Create a deploy class to myproj
@@ -433,11 +433,11 @@ Password used in auth by password.
 
 ##### public_key_file
 
-Public key file path.
+(Optional) Public key file path. If not defined will use current user default public key usually stored in ~/.ssh/id_rsa.pub
 
 ##### private_key_file
 
-Private key file path.
+(Optional) Private key file path. If not defined will use current user default private key usually stored in ~/.ssh/id_rsa.pub
 
 ##### private_key_file_pwd
 

--- a/README.md
+++ b/README.md
@@ -626,7 +626,6 @@ Easy way to manage shared directories.
 
 * Set shared directory for a given path in the project that will be removed and replaced by a symlink to given path to shared directory.
 
-
 #### PhpFpm
 
 Provides methods to restart php-fpm gracefully.
@@ -699,6 +698,19 @@ helper:
         token: your_token
         room_id: your_room_id
 ```
+#### Files
+Provides several methods to work with files.
+* Replace strings that matches the given regular expression in the given array of files:
+ `$this->getHelper('files')->filesReplacePattern(
+              array($this->getLocalNewRepositoryDir() . '/app/config/parameters.yml'),
+              '/database_user: developer_user/',
+              'database_user: production_user'
+  )`
+* Copy files:
+`$this->getHelper('files')->copyFile(
+    $this->getLocalNewRepositoryDir() . '/app/config/parameters.yml.dist',
+    $this->getLocalNewRepositoryDir() . '/app/config/parameters.yml'
+ );`
 
 
 ## TODO

--- a/README.md
+++ b/README.md
@@ -555,7 +555,7 @@ Here and example:
 `src/MyProj/DeployBundle/Service/Test.php:`
 
 
-```
+```php
 <?php
 
 namespace MyProj/DeployBundle/Service;
@@ -618,11 +618,15 @@ class Test extends BaseDeployer
 
 Easy way to manage shared directories.
 
-`$this->getHelper('shared_dirs')->initialize($path)`
+```php
+$this->getHelper('shared_dirs')->initialize($path)
+```
 
 * Initialize given path in the shared directory.
 
-`$this->getHelper('shared_dirs')->set($pathInAppToLink, $pathInSharedDir)`
+```php
+$this->getHelper('shared_dirs')->set($pathInAppToLink, $pathInSharedDir)
+```
 
 * Set shared directory for a given path in the project that will be removed and replaced by a symlink to given path to shared directory.
 
@@ -630,11 +634,15 @@ Easy way to manage shared directories.
 
 Provides methods to restart php-fpm gracefully.
 
-`$this->getHelper('phpfpm')->refresh()`
+```php
+$this->getHelper('phpfpm')->refresh()
+```
 
 * Refresh php-fpm gracefully but you must configure your webserver (e.g. Nginx) to retry the request.
 
-`$this->getHelper('phpfpm')->refreshCommand()`
+```php
+$this->getHelper('phpfpm')->refreshCommand()
+```
 
 * Command used to reload php-fpm
 
@@ -643,11 +651,15 @@ Provides methods to restart php-fpm gracefully.
 
 Helpers to manage composer installation and some commands.
 
-`$this->getHelper('composer')->install()`
+```php
+$this->getHelper('composer')->install()
+```
 
 * Install composer.phar in the new repository dir.
 
-`$this->getHelper('composer')->executeInstall()`
+```php
+$this->getHelper('composer')->executeInstall()
+```
 
 * Executes composer install in the new repository dir.
 * If environment is dev or test --dev parameter is added to composer install
@@ -658,7 +670,9 @@ Helpers to manage composer installation and some commands.
 
 For now only provides a method to do a cache warm up.
 
-`$this->getHelper('symfony2')->cacheWarmUp()`
+```php
+$this->getHelper('symfony2')->cacheWarmUp()
+```
 
 * Do a cache:warmup for production environment
 
@@ -667,7 +681,9 @@ For now only provides a method to do a cache warm up.
 
 Useful methods to have feedback of your deploy in GitHub.
 
-`$this->getHelper('github')->getCompareUrl($gitUidFrom, $gitUidTo)`
+```php
+$this->getHelper('github')->getCompareUrl($gitUidFrom, $gitUidTo)
+```
 
 * Give an url comparing two commits
 * You must set your http url to your GitHub repository in jordi_llonch_deploy.zones parameters:
@@ -678,7 +694,9 @@ helper:
         url: https://github.com/YourUser/Repository
 ```
 
-`$this->getHelper('github')->getCompareUrlFromCurrentCodeToNewRepository()`
+```php
+$this->getHelper('github')->getCompareUrlFromCurrentCodeToNewRepository()
+```
 
 * Give an url comparing commits between current running code and the new downloaded code.
 
@@ -687,7 +705,9 @@ helper:
 
 Provides a method to send messages to a room in a HipChat.
 
-`$this->getHelper('hipchat')->send($msg, $color='purple')`
+```php
+$this->getHelper('hipchat')->send($msg, $color='purple')
+```
 
 * Send a message to a given room
 * You must set your token and room_id to your HipChat in jordi_llonch_deploy.general parameters:
@@ -701,16 +721,20 @@ helper:
 #### Files
 Provides several methods to work with files.
 * Replace strings that matches the given regular expression in the given array of files:
- `$this->getHelper('files')->filesReplacePattern(
+ ```php
+ $this->getHelper('files')->filesReplacePattern(
               array($this->getLocalNewRepositoryDir() . '/app/config/parameters.yml'),
               '/database_user: developer_user/',
               'database_user: production_user'
-  )`
+  );
+  ```
 * Copy files:
-`$this->getHelper('files')->copyFile(
+```php
+$this->getHelper('files')->copyFile(
     $this->getLocalNewRepositoryDir() . '/app/config/parameters.yml.dist',
     $this->getLocalNewRepositoryDir() . '/app/config/parameters.yml'
- );`
+ );
+```
 
 
 ## TODO

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The bundle provides some commands to automatize deploy process. Here are main co
 * **Initialize**: Prepare deployer and remote servers creating a directories structure to host new code.
 * **Download**: Download code from repository, adapt, warn up… and ship it to remote servers in order to put new code to production.
 * **Code to production**. Deploy new code to production atomically and reload web server, app…
+* **Migrate**: Run database migrations.
 * **Rollback**. Return back to previous deployed version.
 
 Deployer have zones configured to deploy new code.
@@ -217,7 +218,6 @@ After download you just need to put code into production.
 app/console deployer:code2production --zones=prod_myproj
 ```
 
-
 ### Rollback
 
 If there is any problem you can roll back to a previous version. See rollback command help.
@@ -250,7 +250,11 @@ Deploy new code to production atomically and reload web server, app...
 ```sh
 app/console deployer:code2production --zones=[zone1,zone2...]
 ```
-
+### Migrate
+Perform migrations on your enviroment database
+```sh
+app/console deployer:migrate [version_number] --zones=prod_myproj
+```
 
 ### syncronize
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Usually, after that you should restart webserver or php-fpm.
 ### Create a new Symfony 2.3 project
  
 
-```    
+```sh
 php composer.phar create-project symfony/framework-standard-edition path/ 2.3.0
 ```
 
@@ -65,7 +65,7 @@ php composer.phar create-project symfony/framework-standard-edition path/ 2.3.0
 
 Add following lines to your `composer.json` file:
 
-```
+```json
 "require": {
   "jordillonch/deploy-bundle": "dev-master"
 },
@@ -73,13 +73,13 @@ Add following lines to your `composer.json` file:
 ```
 Execute:
 
-```
+```sh
 php composer.phar update
 ```
 
 Add it to the `AppKernel.php` class:
 
-```
+```php
 new JordiLlonch\Bundle\DeployBundle\JordiLlonchDeployBundle(),
 ```
     
@@ -89,7 +89,7 @@ new JordiLlonch\Bundle\DeployBundle\JordiLlonchDeployBundle(),
 
 `app/config/parameters.yml`
 
-```
+```yml
 jordi_llonch_deploy:
     config:
         project: MyProject
@@ -114,7 +114,7 @@ jordi_llonch_deploy:
 
 `app/config/parameters_deployer_servers.yml`
 
-```
+```yml
 prod_myproj:
     urls:
         - deploy@testserver1:8822
@@ -128,7 +128,7 @@ prod_myproj:
 
 * First create your own bundle:
 
-```
+```sh
 php app/console generate:bundle --namespace=MyProj/DeployBundle --dir=src --no-interaction
 ```
 
@@ -137,7 +137,7 @@ php app/console generate:bundle --namespace=MyProj/DeployBundle --dir=src --no-i
 `src/MyProj/DeployBundle/Service/Test.php:`
 
 
-```
+```php
 <?php
 
 namespace MyProj/DeployBundle/Service;
@@ -177,7 +177,7 @@ class Test extends BaseDeployer
 
 * Add your deploy class as a service with tag: `jordi_llonch_deploy`
 
-```
+```xml
 <service id="myproj.deployer.test" class="MyProj/DeployBundle/Service/Test">
     <tag name="jordi_llonch_deploy" deployer="myproj"/>
 </service>
@@ -195,7 +195,7 @@ It is necessary to add the public key of the deploy user to `.ssh/authorized_key
 
 After configure the deployer you have to do the initialization.
 
-```
+```sh
 app/console deployer:initialize --zones=prod_myproj
 ```
 
@@ -204,7 +204,7 @@ app/console deployer:initialize --zones=prod_myproj
 
 Now you can download code from your repository and copy to your servers.
 
-```
+```sh
 app/console deployer:download --zones=prod_myproj
 ```
 
@@ -213,7 +213,7 @@ app/console deployer:download --zones=prod_myproj
 
 After download you just need to put code into production.
 
-```
+```sh
 app/console deployer:code2production --zones=prod_myproj
 ```
 
@@ -230,7 +230,7 @@ If there is any problem you can roll back to a previous version. See rollback co
 
 Prepare deployer and remote servers creating a directories structure to host new code.
 
-```
+```sh
 app/console deployer:initialize --zones=[zone1,zone2...]
 ```
 
@@ -239,7 +239,7 @@ app/console deployer:initialize --zones=[zone1,zone2...]
 
 Download code from repository, adapt, warn up… and ship it to remote servers in order to put new code to production.
 
-```
+```sh
 app/console deployer:download --zones=[zone1,zone2...]
 ```
 
@@ -247,7 +247,7 @@ app/console deployer:download --zones=[zone1,zone2...]
 
 Deploy new code to production atomically and reload web server, app...
 
-```
+```sh
 app/console deployer:code2production --zones=[zone1,zone2...]
 ```
 
@@ -257,7 +257,7 @@ app/console deployer:code2production --zones=[zone1,zone2...]
 Ensure that all downloaded versions of code are copied to all servers.
 Useful when you add a new server to a zone. If you not syncronize the new server the rollback operation will break the code in the new server.
 
-```
+```sh
 app/console deployer:syncronize --zones=prod_myproj
 ```
 
@@ -269,7 +269,7 @@ If there is any problem and you need to roll back to a previous version you have
 
 #### Using number of steps to roll back
 
-```
+```sh
 app/console deployer:rollback execute [steps_backward] --zones=[zone1]
 ```
 
@@ -280,13 +280,13 @@ app/console deployer:rollback execute [steps_backward] --zones=[zone1]
 
 1) Ask deploy for available versions to rollback.
 
-```
+```sh
 app/console deployer:rollback list --zones=[zone1]
 ```
 
 2) Execute rollback to specific version
 
-```
+```sh
 app/console deployer:rollback execute [version] --zones=[zone1]
 ```
 
@@ -295,7 +295,7 @@ app/console deployer:rollback execute [version] --zones=[zone1]
 
 Shows running version and last downloaded version prepared to put to production.
 
-```
+```sh
 app/console deployer:status [--zones=[zone1,zone2...]]
 ```
 
@@ -304,7 +304,7 @@ app/console deployer:status [--zones=[zone1,zone2...]]
 
 Configure remote servers for zones. Useful for automatize scaling.
 
-```
+```sh
 app/console deployer:configure zone [add, set, rm, list, list_json] [url]
 ```
 
@@ -313,7 +313,7 @@ app/console deployer:configure zone [add, set, rm, list, list_json] [url]
 
 Remove old code. Left `clean_max_deploys` deploys.
 
-```
+```sh
 app/console deployer:clean
 ```
 
@@ -322,7 +322,7 @@ app/console deployer:clean
 
 Executes command passed as argument to all configured servers.
 
-```
+```sh
 app/console deployer:exec2servers [command]
 ```
 
@@ -338,7 +338,7 @@ You must set general configurations and zones.
 
 `app/config/parameters.yml`
 
-```
+```yml
 jordi_llonch_deploy:
     config:
         project: MyProject
@@ -402,7 +402,7 @@ Ssh configuration to establish connections on remote servers to execute commands
 
 Here an example of configuration:
 
-```
+```yml
 ssh:
     proxy: cli
     user: jllonch
@@ -474,7 +474,7 @@ jordi_llonch_deploy:
 
 `app/config/parameters_deployer_servers.yml`
 
-```
+```yml
 prod_myproj:
     urls:
         - deploy@testserver1:8822
@@ -485,7 +485,7 @@ prod_myproj:
 
 Name of the service used to deploy the zone.
 
-```
+```xml
 <service id="myproj.deployer.test" class="MyProj/DeployBundle/Service/Test">
     <tag name="jordi_llonch_deploy" deployer="myproj"/>
 </service>
@@ -721,14 +721,17 @@ helper:
 #### Files
 Provides several methods to work with files.
 * Replace strings that matches the given regular expression in the given array of files:
- ```php
+
+```php
  $this->getHelper('files')->filesReplacePattern(
               array($this->getLocalNewRepositoryDir() . '/app/config/parameters.yml'),
               '/database_user: developer_user/',
               'database_user: production_user'
   );
-  ```
+```
+
 * Copy files:
+
 ```php
 $this->getHelper('files')->copyFile(
     $this->getLocalNewRepositoryDir() . '/app/config/parameters.yml.dist',

--- a/SSH/LocalhostProxy.php
+++ b/SSH/LocalhostProxy.php
@@ -47,7 +47,7 @@ class LocalhostProxy extends BaseProxy
 
         if(!empty($output)) foreach($output as $item) $this->logger->debug('exec output: ' . $item);
 
-        if($returnVar == 0) $this->lastOutput = implode("\n", $output);
+        if($returnVar == 0) $this->lastOutput = $outputLastLine;
         else $this->lastError = $outputLastLine;
 
         return $returnVar;

--- a/Service/BaseDeployer.php
+++ b/Service/BaseDeployer.php
@@ -19,6 +19,7 @@ use JordiLlonch\Bundle\DeployBundle\Helpers\PhpFpmHelper;
 use JordiLlonch\Bundle\DeployBundle\Helpers\SharedDirsHelper;
 use JordiLlonch\Bundle\DeployBundle\Helpers\Symfony2;
 use JordiLlonch\Bundle\DeployBundle\Helpers\Symfony2Helper;
+use JordiLlonch\Bundle\DeployBundle\Helpers\FilesHelper;
 use JordiLlonch\Bundle\DeployBundle\SSH\SshManager;
 use JordiLlonch\Bundle\DeployBundle\VCS\VcsFactory;
 use JordiLlonch\Bundle\DeployBundle\VCS\VcsInterface;

--- a/Service/BaseDeployer.php
+++ b/Service/BaseDeployer.php
@@ -980,4 +980,29 @@ abstract class BaseDeployer implements DeployerInterface
         return $arrListDir;
     }
 
+    public function runMigration($version = false)
+    {
+        // Check if deployer has been initialized
+        if(!file_exists($this->getLocalRepositoryDir())) throw new \Exception('It seems deployer has not been initialized.');
+
+        if($version == false)
+        {
+            $this->migrateLatest();
+        }
+        else
+        {
+            $this->migrateVersion($version);
+        }
+    }
+
+    protected function migrateLatest()
+    {
+        $this->exec('php ' . $this->getLocalNewRepositoryDir() . '/app/console doctrine:migrations:migrate --env=prod --no-debug');
+    }
+
+    protected function migrateVersion($version)
+    {
+        $this->exec('php ' . $this->getLocalNewRepositoryDir() . '/app/console doctrine:migrations:migrate '.$version.' --env=prod --no-debug');
+    }
+
 }

--- a/Service/BaseDeployer.php
+++ b/Service/BaseDeployer.php
@@ -669,13 +669,14 @@ abstract class BaseDeployer implements DeployerInterface
 
     abstract protected function runClearCache();
 
-    public function exec($command)
+    public function exec($command,$timeout = 3600)
     {
         $this->logger->debug('exec: ' . $command);
 
         if ($this->dryMode) return;
 
         $process = new Process($command);
+        $process->setTimeout($timeout);
         $process->run();
 
         $process_output = $process->getOutput();

--- a/Service/BaseDeployer.php
+++ b/Service/BaseDeployer.php
@@ -451,7 +451,7 @@ abstract class BaseDeployer implements DeployerInterface
         }
         else
         {
-            if($this->sshConfig['private_key_file'] != null)
+            if(array_key_exists('private_key_file',$this->sshConfig) && $this->sshConfig['private_key_file'] != null)
             {
                 $this->exec('rsync -ar --delete -e "ssh -p ' . $port . ' -i \"' . $this->sshConfig['private_key_file'] . '\" -l ' . $this->sshConfig['user'] . ' -o \"UserKnownHostsFile=/dev/null\" -o \"StrictHostKeyChecking=no\"" ' . $rsyncParams . ' "' . $originPath . '" "' . $host . ':' . $serverPath . '"');
             }

--- a/Service/BaseDeployer.php
+++ b/Service/BaseDeployer.php
@@ -103,6 +103,7 @@ abstract class BaseDeployer implements DeployerInterface
             new HipChatHelper(),
             new PhpFpmHelper(),
             new Symfony2Helper(),
+            new FilesHelper()
         );
     }
 

--- a/Service/BaseDeployer.php
+++ b/Service/BaseDeployer.php
@@ -445,8 +445,22 @@ abstract class BaseDeployer implements DeployerInterface
     public function rsync($originPath, $server, $serverPath, $rsyncParams = '')
     {
         list($host, $port) = $this->extractHostPort($server);
-        if ($host == 'localhost') $this->exec('cp -a "' . $originPath . '" "' . $serverPath . '"');
-        else $this->exec('rsync -ar --delete -e "ssh -p ' . $port . ' -i \"' . $this->sshConfig['private_key_file'] . '\" -l ' . $this->sshConfig['user'] . ' -o \"UserKnownHostsFile=/dev/null\" -o \"StrictHostKeyChecking=no\"" ' . $rsyncParams . ' "' . $originPath . '" "' . $host . ':' . $serverPath . '"');
+        if ($host == 'localhost')
+        {
+            $this->exec('cp -a "' . $originPath . '" "' . $serverPath . '"');
+        }
+        else
+        {
+            if($this->sshConfig['private_key_file'] != null)
+            {
+                $this->exec('rsync -ar --delete -e "ssh -p ' . $port . ' -i \"' . $this->sshConfig['private_key_file'] . '\" -l ' . $this->sshConfig['user'] . ' -o \"UserKnownHostsFile=/dev/null\" -o \"StrictHostKeyChecking=no\"" ' . $rsyncParams . ' "' . $originPath . '" "' . $host . ':' . $serverPath . '"');
+            }
+            else
+            {
+                $this->exec('rsync -ar --delete -e "ssh -p ' . $port . ' -l ' . $this->sshConfig['user'] . ' -o \"UserKnownHostsFile=/dev/null\" -o \"StrictHostKeyChecking=no\"" ' . $rsyncParams . ' "' . $originPath . '" "' . $host . ':' . $serverPath . '"');
+            }
+
+        }
     }
 
     /**

--- a/Service/BaseDeployer.php
+++ b/Service/BaseDeployer.php
@@ -668,7 +668,7 @@ abstract class BaseDeployer implements DeployerInterface
 
         if(!$process->isSuccessful())
         {
-            throw new \Exception('ERROR executing: ' . $command . "\n" .$process_output);
+            throw new \Exception('ERROR executing: ' . $command . "\n" .$process->getErrorOutput());
         }
 
         if(!empty($process_output))

--- a/Service/BaseDeployer.php
+++ b/Service/BaseDeployer.php
@@ -668,7 +668,7 @@ abstract class BaseDeployer implements DeployerInterface
 
         if(!$process->isSuccessful())
         {
-            throw new \Exception('ERROR executing: ' . $command . "\n" .$output);
+            throw new \Exception('ERROR executing: ' . $command . "\n" .$process_output);
         }
 
         if(!empty($process_output))

--- a/Service/BaseDeployer.php
+++ b/Service/BaseDeployer.php
@@ -664,14 +664,14 @@ abstract class BaseDeployer implements DeployerInterface
         $process = new Process($command);
         $process->run();
 
+        $process_output = $process->getOutput();
+
         if(!$process->isSuccessful())
         {
             throw new \Exception('ERROR executing: ' . $command . "\n" .$output);
         }
 
-        $process_output = $process->getOutput();
-
-        if(!empty($output))
+        if(!empty($process_output))
         {
             $this->logger->debug('exec output: ' . $process_output);
         }

--- a/Service/DeployerInterface.php
+++ b/Service/DeployerInterface.php
@@ -42,7 +42,7 @@ interface DeployerInterface {
 
     public function downloadCode();
     public function downloadCodeRollback();
-    public function exec($command, &$output = null);
+    public function exec($command);
     public function execRemoteServers($command, $urls = null);
     public function rsync($originPath, $server, $serverPath, $rsyncParams = '');
     public function rsync2Servers($originPath, $targetPath, $rsyncParams = '');

--- a/Service/DeployerInterface.php
+++ b/Service/DeployerInterface.php
@@ -42,7 +42,7 @@ interface DeployerInterface {
 
     public function downloadCode();
     public function downloadCodeRollback();
-    public function exec($command);
+    public function exec($command,$timeout = 3600);
     public function execRemoteServers($command, $urls = null);
     public function rsync($originPath, $server, $serverPath, $rsyncParams = '');
     public function rsync2Servers($originPath, $targetPath, $rsyncParams = '');


### PR DESCRIPTION
This PR contains some fixes and some improvements.
- **Make private ssh key not required in config.yml:** In some cases ssh keys are not needed. For example in our deploy config we passthrough the keys from other computers, so we don't use the same keys that are stored in our deployer machines.
- **Make use of symfony process component in exec method of base deployer**: In some parts of the code (CLISshProxy) it's used the symfony process component. In other parts is php exec that is used. The main idea is to try to standarize it. That's why I've added the process component in Base deployer's exec.
- **Add files helper to base helperset**: Files Helper was not loaded by default in base helper. It seems very useful to have it initialized. I think all symfony 2 deploys can make use of filereplacepattern function.
- **Add copy function to file helper**: I've added a copy function just to encapsulate things a little bit because a copy function is quite useful.
- **Changes in documentation**: Changes in documentation to reflect changes made in code.
